### PR TITLE
Multi cohort calib

### DIFF
--- a/src/configs.py
+++ b/src/configs.py
@@ -19,7 +19,7 @@ START_AGE = 0
 END_AGE = 100
 COHORT_SEX = 'Male'  # Female/Male
 COHORT_RACE = 'White'  # Black/White
-NUM_PATIENTS = 100
+NUM_PATIENTS = 100_000
 CANCER_SITES = ['Pancreas']
 # Full list:
 # MP 'Bladder' 'Breast' 'Cervical' 'Colorectal' 'Esophageal' 
@@ -33,7 +33,7 @@ elif COHORT_SEX == 'Female' and 'Prostate' in CANCER_SITES:
     raise Exception("Cancer site and cohort sex combination is not valid in configs.py")
 
 # Define simulated annealing parameters
-NUM_ITERATIONS = 10
+NUM_ITERATIONS = 1_000
 START_TEMP = 10
 STEP_SIZE = 0.001
 VERBOSE = True
@@ -46,13 +46,13 @@ if MULTI_COHORT_CALIBRATION:
 
 # Define input and output paths
 PATHS = {
-    'incidence': '../data/cancer_incidence/',
-    'mortality': '../data/mortality/',
-    'survival': '../data/cancer_survival/',
-    'calibration': '../outputs/calibration/',
-    'plots_calibration': '../outputs/calibration/plots/',
-    'sojourn_time': '../data/Sojourn Times/',
-    'plots': '../outputs/plots/'
+    'incidence': './data/cancer_incidence/',
+    'mortality': './data/mortality/',
+    'survival': './data/cancer_survival/',
+    'calibration': './outputs/calibration/',
+    'plots_calibration': './outputs/calibration/plots/',
+    'sojourn_time': './data/Sojourn Times/',
+    'plots': './outputs/plots/'
 }
 
 

--- a/src/configs.py
+++ b/src/configs.py
@@ -19,12 +19,12 @@ START_AGE = 0
 END_AGE = 100
 COHORT_SEX = 'Female'  # Female/Male
 COHORT_RACE = 'White'  # Black/White
-NUM_PATIENTS = 100_000
+NUM_PATIENTS = 100
 CANCER_SITES = ['Breast']
 # Full list:
 # MP 'Bladder' 'Breast' 'Cervical' 'Colorectal' 'Esophageal' 
 # JP 'Gastric' 'Lung' 'Prostate' 'Uterine'
-# FL 'Pancreatic' 'Ovarian' 'Kidney' 'Brain' 'Liver' 'Gallbladder'
+# FL 'Pancreas' 'Ovarian' 'Kidney' 'Brain' 'Liver' 'Gallbladder'
 
 # Raise exceptions for male/ovarian, male/uterine, male/cervical, female/prostrate
 if COHORT_SEX == 'Male' and ('Ovarian' in CANCER_SITES or 'Uterine' in CANCER_SITES or 'Cervical' in CANCER_SITES):
@@ -39,16 +39,20 @@ STEP_SIZE = 0.001
 VERBOSE = True
 MASK_SIZE = 0.1  # value between 0 and 1, the fraction of values to modify each step
 LOAD_LATEST = True  # If true, load the latest cancer_pdf from file as starting point
+MULTI_COHORT_CALIBRATION = True
+if MULTI_COHORT_CALIBRATION:
+    FIRST_COHORT = 1941
+    LAST_COHORT = 1945
 
 # Define input and output paths
 PATHS = {
-    'incidence': './data/cancer_incidence/',
-    'mortality': './data/mortality/',
-    'survival': './data/cancer_survival/',
-    'calibration': './outputs/calibration/',
-    'plots_calibration': './outputs/calibration/plots/',
-    'sojourn_time': './data/Sojourn Times/',
-    'plots': './outputs/plots/'
+    'incidence': '../data/cancer_incidence/',
+    'mortality': '../data/mortality/',
+    'survival': '../data/cancer_survival/',
+    'calibration': '../outputs/calibration/',
+    'plots_calibration': '../outputs/calibration/plots/',
+    'sojourn_time': '../data/Sojourn Times/',
+    'plots': '../outputs/plots/'
 }
 
 # Load input data
@@ -69,70 +73,71 @@ sojourn = pd.read_csv(PATHS['sojourn_time'] + 'Sojourn Estimates.csv')
 sojourn = sojourn[sojourn['Site'].isin(CANCER_SITES)]
 
 # Selecting Cohort
-CANCER_INC.query('Sex == @COHORT_SEX & Race == @COHORT_RACE & Cohort == @COHORT_YEAR', inplace=True)
-MORT.query('Sex == @COHORT_SEX & Race == @COHORT_RACE & Cohort == @COHORT_YEAR', inplace=True)
-SURV.query('Sex == @COHORT_SEX & Race == @COHORT_RACE', inplace=True)
+def select_cohort(birthyear, CANCER_INC, MORT, SURV, sojourn):
+    CANCER_INC.query('Sex == @COHORT_SEX & Race == @COHORT_RACE & Cohort == @COHORT_YEAR', inplace=True)
+    MORT.query('Sex == @COHORT_SEX & Race == @COHORT_RACE & Cohort == @COHORT_YEAR', inplace=True)
+    SURV.query('Sex == @COHORT_SEX & Race == @COHORT_RACE', inplace=True)
 
-# Create the cdf all-cause mortality
-ac_cdf = np.cumsum(MORT['Rate'].to_numpy())/100000
-# Creating the conditional CDF for all-cause mortality by age (doing this here to save runtime)
-ac_cdf = np.tile(ac_cdf, (END_AGE - START_AGE + 1, 1))  # (current age, future age)
-for i in range(END_AGE - START_AGE + 1):
-    ac_cdf[i, :] -= ac_cdf[i, i]  # Subtract the death at current age
-ac_cdf[:, -1] = 1.0  # Adding 1.0 to the end to ensure death at 100
-ac_cdf = np.clip(ac_cdf, 0.0, 1.0)
+    # Create the cdf all-cause mortality
+    ac_cdf = np.cumsum(MORT['Rate'].to_numpy())/100000
+    # Creating the conditional CDF for all-cause mortality by age (doing this here to save runtime)
+    ac_cdf = np.tile(ac_cdf, (END_AGE - START_AGE + 1, 1))  # (current age, future age)
+    for i in range(END_AGE - START_AGE + 1):
+        ac_cdf[i, :] -= ac_cdf[i, i]  # Subtract the death at current age
+    ac_cdf[:, -1] = 1.0  # Adding 1.0 to the end to ensure death at 100
+    ac_cdf = np.clip(ac_cdf, 0.0, 1.0)
 
+    # Load all cancer incidence target data
+    CANCER_INC = CANCER_INC['Rate'].to_numpy()
+    # For plotting and objective, we only compare years we have data
+    min_age = max(1975 - COHORT_YEAR, 0)
+    max_age = min(2018 - COHORT_YEAR, 84)
 
-# Load all cancer incidence target data
-CANCER_INC = CANCER_INC['Rate'].to_numpy()
-# For plotting and objective, we only compare years we have data
-min_age = max(1975 - COHORT_YEAR, 0)
-max_age = min(2018 - COHORT_YEAR, 84)
+    # Loading in cancer pdf, this is the thing that will be optimized over
+    CANCER_PDF = 0.002 * np.ones(END_AGE - START_AGE + 1)  # starting from 0 incidence and using bias optimization
+    CANCER_PDF[:35] = 0.0
+    if LOAD_LATEST:
+        # Check if there is a previous numpy file matching the same sex and race and cancer site
+        list_of_files = glob.glob(f'{PATHS["calibration"]}*{COHORT_SEX}_{COHORT_RACE}_*{CANCER_SITES[0]}_*.npy')
+        if len(list_of_files) == 0: # Check if there is a previous numpy file matching the same sex and cancer site
+            list_of_files = glob.glob(f'{PATHS["calibration"]}*{COHORT_SEX}_*{CANCER_SITES[0]}_*.npy')
+        if len(list_of_files) == 0: # Check if there is a previous numpy file matching the same race and cancer site
+            list_of_files = glob.glob(f'{PATHS["calibration"]}*{COHORT_RACE}_*{CANCER_SITES[0]}_*.npy')
+        if len(list_of_files) == 0: # Check if there is a previous numpy file matching the same cancer site
+            list_of_files = glob.glob(f'{PATHS["calibration"]}*{CANCER_SITES[0]}_*.npy')
+        if len(list_of_files) == 0:
+            raise ValueError("No suitable LOAD_LATEST file, set LOAD_LATEST to FALSE")
 
-# Loading in cancer pdf, this is the thing that will be optimized over
-CANCER_PDF = 0.002 * np.ones(END_AGE - START_AGE + 1)  # starting from 0 incidence and using bias optimization
-CANCER_PDF[:35] = 0.0
-if LOAD_LATEST:
-    # Check if there is a previous numpy file matching the same sex and race and cancer site
-    list_of_files = glob.glob(f'{PATHS["calibration"]}*{COHORT_SEX}_{COHORT_RACE}_*{CANCER_SITES[0]}_*.npy')
-    if len(list_of_files) == 0: # Check if there is a previous numpy file matching the same sex and cancer site
-        list_of_files = glob.glob(f'{PATHS["calibration"]}*{COHORT_SEX}_*{CANCER_SITES[0]}_*.npy')
-    if len(list_of_files) == 0: # Check if there is a previous numpy file matching the same race and cancer site
-        list_of_files = glob.glob(f'{PATHS["calibration"]}*{COHORT_RACE}_*{CANCER_SITES[0]}_*.npy')
-    if len(list_of_files) == 0: # Check if there is a previous numpy file matching the same cancer site
-        list_of_files = glob.glob(f'{PATHS["calibration"]}*{CANCER_SITES[0]}_*.npy')
-    if len(list_of_files) == 0:
-        raise ValueError("No suitable LOAD_LATEST file, set LOAD_LATEST to FALSE")
+        # Look at all the unique cohort years in the file names
+        all_cohort_years = []
+        for file in list_of_files:
+            year = file.split('_')[2] # grabs the cohort year
+            if int(year) not in all_cohort_years:
+                all_cohort_years.append(int(year))
+        # Sort ascending years
+        all_cohort_years.sort()
+        # Get the max calibrated cohort year that is just below or equal to the COHORT_YEAR
+        for year in all_cohort_years:
+            if year <= COHORT_YEAR:
+                max_year = year
+        final_list = []
+        for file in list_of_files:
+            if f'_{max_year}_' in file:
+                final_list.append(file)
+        # Read the latest file
+        latest_file = max(final_list, key=os.path.getctime)
+        CANCER_PDF = np.load(latest_file)
 
-    # Look at all the unique cohort years in the file names
-    all_cohort_years = []
-    for file in list_of_files:
-        year = file.split('_')[2] # grabs the cohort year
-        if int(year) not in all_cohort_years:
-            all_cohort_years.append(int(year))
-    # Sort ascending years
-    all_cohort_years.sort()
-    # Get the max calibrated cohort year that is just below or equal to the COHORT_YEAR
-    for year in all_cohort_years:
-        if year <= COHORT_YEAR:
-            max_year = year
-    final_list = []
-    for file in list_of_files:
-        if f'_{max_year}_' in file:
-            final_list.append(file)
-    # Read the latest file
-    latest_file = max(final_list, key=os.path.getctime)
-    CANCER_PDF = np.load(latest_file)
+    # Loading in cancer survival data
+    SURV = SURV[['Cancer_Death','Other_Death']].to_numpy()  # 10 year survival
+    SURV = 1 - SURV**(1/10)  # Converting to annual probability of death (assuming constant rate)
 
-# Loading in cancer survival data
-SURV = SURV[['Cancer_Death','Other_Death']].to_numpy()  # 10 year survival
-SURV = 1 - SURV**(1/10)  # Converting to annual probability of death (assuming constant rate)
+    # Converting into probability of death at each follow up year
+    cancer_surv_arr = np.zeros((END_AGE - START_AGE + 1, 10, 2))
 
-# Converting into probability of death at each follow up year
-cancer_surv_arr = np.zeros((END_AGE - START_AGE + 1, 10, 2))
+    for i in range(10):
+        cancer_surv_arr[:,i,0] = 1-(1-SURV[:,0])**(i+1)  # Cancer death
+        cancer_surv_arr[:,i,1] = 1-(1-SURV[:,1])**(i+1)  # Other death
+        # This is now an an array of shape (100, 10, 2), that represents the cdf of cancer death and other death at each follow up year
 
-for i in range(10):
-    cancer_surv_arr[:,i,0] = 1-(1-SURV[:,0])**(i+1)  # Cancer death
-    cancer_surv_arr[:,i,1] = 1-(1-SURV[:,1])**(i+1)  # Other death
-
-# This is now an an array of shape (100, 10, 2), that represents the cdf of cancer death and other death at each follow up year
+    return ac_cdf, min_age, max_age, CANCER_PDF, cancer_surv_arr, CANCER_INC

--- a/src/configs.py
+++ b/src/configs.py
@@ -33,13 +33,13 @@ elif COHORT_SEX == 'Female' and 'Prostate' in CANCER_SITES:
     raise Exception("Cancer site and cohort sex combination is not valid in configs.py")
 
 # Define simulated annealing parameters
-NUM_ITERATIONS = 100
+NUM_ITERATIONS = 10
 START_TEMP = 10
 STEP_SIZE = 0.001
 VERBOSE = True
 MASK_SIZE = 0.1  # value between 0 and 1, the fraction of values to modify each step
-LOAD_LATEST = True  # If true, load the latest cancer_pdf from file as starting point
-MULTI_COHORT_CALIBRATION = True
+LOAD_LATEST = False  # If true, load the latest cancer_pdf from file as starting point
+MULTI_COHORT_CALIBRATION = False
 if MULTI_COHORT_CALIBRATION:
     FIRST_COHORT = 1941
     LAST_COHORT = 1945
@@ -55,31 +55,33 @@ PATHS = {
     'plots': '../outputs/plots/'
 }
 
-# Load input data
-CANCER_INC = pd.read_csv(f'{PATHS["incidence"]}Incidence.csv')
-CANCER_INC = CANCER_INC[CANCER_INC['Site'].isin(CANCER_SITES)]  # keeping the cancers of interest
 
-# Load in mortality data
-MORT = pd.read_csv(f'{PATHS["mortality"]}Mortality.csv')
-MORT = MORT[~MORT['Site'].isin(CANCER_SITES)]  # Removing the cancers of interest
-MORT = MORT.groupby(['Cohort','Age','Sex','Race']).agg({'Rate':'sum'}).reset_index()  # Summing over the remaining sites
-
-# Load in Survival data # TODO: no male breast survival data
-SURV = pd.read_csv(f'{PATHS["survival"]}Survival.csv')  # This is the 10 year survival by cause
-SURV = SURV[SURV['Site'].isin(CANCER_SITES)]  # keeping the cancers of interest
-
-# Load in sojorn times
-sojourn = pd.read_csv(PATHS['sojourn_time'] + 'Sojourn Estimates.csv')
-sojourn = sojourn[sojourn['Site'].isin(CANCER_SITES)]
 
 # Selecting Cohort
-def select_cohort(birthyear, sex, race, CANCER_INC, MORT, SURV, sojourn):
-    NEW_CANCER_INC = CANCER_INC.query('Sex == @sex & Race == @race & Cohort == @birthyear', inplace=True)
-    NEW_MORT = MORT.query('Sex == @sex & Race == @race & Cohort == @birthyear', inplace=True)
-    NEW_SURV = SURV.query('Sex == @sex & Race == @race', inplace=True)
+def select_cohort(birthyear, sex, race):
+    # Load input data
+    CANCER_INC = pd.read_csv(f'{PATHS["incidence"]}Incidence.csv')
+    CANCER_INC = CANCER_INC[CANCER_INC['Site'].isin(CANCER_SITES)]  # keeping the cancers of interest
+
+    # Load in mortality data
+    MORT = pd.read_csv(f'{PATHS["mortality"]}Mortality.csv')
+    MORT = MORT[~MORT['Site'].isin(CANCER_SITES)]  # Removing the cancers of interest
+    MORT = MORT.groupby(['Cohort','Age','Sex','Race']).agg({'Rate':'sum'}).reset_index()  # Summing over the remaining sites
+
+    # Load in Survival data # TODO: no male breast survival data
+    SURV = pd.read_csv(f'{PATHS["survival"]}Survival.csv')  # This is the 10 year survival by cause
+    SURV = SURV[SURV['Site'].isin(CANCER_SITES)]  # keeping the cancers of interest
+
+    # Load in sojorn times
+    sojourn = pd.read_csv(PATHS['sojourn_time'] + 'Sojourn Estimates.csv')
+    sojourn = sojourn[sojourn['Site'].isin(CANCER_SITES)]
+
+    CANCER_INC.query('Sex == @sex & Race == @race & Cohort == @birthyear', inplace=True)
+    MORT.query('Sex == @sex & Race == @race & Cohort == @birthyear', inplace=True)
+    SURV.query('Sex == @sex & Race == @race', inplace=True)
 
     # Create the cdf all-cause mortality
-    ac_cdf = np.cumsum(NEW_MORT['Rate'].to_numpy())/100000
+    ac_cdf = np.cumsum(MORT['Rate'].to_numpy())/100000
     # Creating the conditional CDF for all-cause mortality by age (doing this here to save runtime)
     ac_cdf = np.tile(ac_cdf, (END_AGE - START_AGE + 1, 1))  # (current age, future age)
     for i in range(END_AGE - START_AGE + 1):
@@ -88,10 +90,10 @@ def select_cohort(birthyear, sex, race, CANCER_INC, MORT, SURV, sojourn):
     ac_cdf = np.clip(ac_cdf, 0.0, 1.0)
 
     # Load all cancer incidence target data
-    NEW_CANCER_INC = NEW_CANCER_INC['Rate'].to_numpy()
+    CANCER_INC = CANCER_INC['Rate'].to_numpy()
     # For plotting and objective, we only compare years we have data
-    min_age = max(1975 - COHORT_YEAR, 0)
-    max_age = min(2018 - COHORT_YEAR, 84)
+    min_age = max(1975 - birthyear, 0)
+    max_age = min(2018 - birthyear, 84)
 
     # Loading in cancer pdf, this is the thing that will be optimized over
     CANCER_PDF = 0.002 * np.ones(END_AGE - START_AGE + 1)  # starting from 0 incidence and using bias optimization
@@ -118,7 +120,7 @@ def select_cohort(birthyear, sex, race, CANCER_INC, MORT, SURV, sojourn):
         all_cohort_years.sort()
         # Get the max calibrated cohort year that is just below or equal to the COHORT_YEAR
         for year in all_cohort_years:
-            if year <= COHORT_YEAR:
+            if year <= birthyear:
                 max_year = year
         final_list = []
         for file in list_of_files:
@@ -129,15 +131,15 @@ def select_cohort(birthyear, sex, race, CANCER_INC, MORT, SURV, sojourn):
         CANCER_PDF = np.load(latest_file)
 
     # Loading in cancer survival data
-    NEW_SURV = NEW_SURV[['Cancer_Death','Other_Death']].to_numpy()  # 10 year survival
-    NEW_SURV = 1 - NEW_SURV**(1/10)  # Converting to annual probability of death (assuming constant rate)
+    SURV = SURV[['Cancer_Death','Other_Death']].to_numpy()  # 10 year survival
+    SURV = 1 - SURV**(1/10)  # Converting to annual probability of death (assuming constant rate)
 
     # Converting into probability of death at each follow up year
     cancer_surv_arr = np.zeros((END_AGE - START_AGE + 1, 10, 2))
 
     for i in range(10):
-        cancer_surv_arr[:,i,0] = 1-(1-NEW_SURV[:,0])**(i+1)  # Cancer death
-        cancer_surv_arr[:,i,1] = 1-(1-NEW_SURV[:,1])**(i+1)  # Other death
+        cancer_surv_arr[:,i,0] = 1-(1-SURV[:,0])**(i+1)  # Cancer death
+        cancer_surv_arr[:,i,1] = 1-(1-SURV[:,1])**(i+1)  # Other death
         # This is now an an array of shape (100, 10, 2), that represents the cdf of cancer death and other death at each follow up year
 
     return ac_cdf, min_age, max_age, CANCER_PDF, cancer_surv_arr, CANCER_INC

--- a/src/main.py
+++ b/src/main.py
@@ -5,10 +5,10 @@ from datetime import timedelta, datetime
 import matplotlib.pyplot as plt
 import configs as c
 from classes import *
+from tqdm import tqdm
 
 if __name__ == '__main__':
     start = timer()
-    model = DiscreteEventSimulation()
     if c.MODE == 'visualize':
         # Run simplest verion of the model
         print(objective(model.run(c.CANCER_PDF).cancerIncArr, c.CANCER_INC))
@@ -20,20 +20,45 @@ if __name__ == '__main__':
         plt.title(f"Cancer Incidence by Age for Birthyear={c.COHORT_YEAR}, Sex={c.COHORT_SEX}, Race={c.COHORT_RACE}, Site={c.CANCER_SITES[0]}")
         plt.show()
     elif c.MODE == 'calibrate':
-        print(f"RUNNING CALIBRATION: COHORT = {c.COHORT_YEAR}, SEX = {c.COHORT_SEX}, RACE = {c.COHORT_RACE}")
-        print(f"CANCERS = {c.CANCER_SITES}")
-        # Run calibration for simplest verion of the model
-        best = simulated_annealing(model)
-        # Save as numpy file, time_stamped
-        if c.SAVE_RESULTS:
-            np.save(c.PATHS['calibration'] + f"{c.COHORT_SEX}_{c.COHORT_RACE}_{c.COHORT_YEAR}_{c.CANCER_SITES[0]}_{datetime.now():%Y-%m-%d_%H-%M-%S}.npy", best)
-        plt.plot(np.arange(c.START_AGE, c.END_AGE), model.run(best).cancerIncArr[:-1], label='Model', color='blue')
-        plt.plot(np.arange(c.min_age, c.max_age+1), c.CANCER_INC, label='SEER', color='darkred', alpha=0.5)
-        plt.legend(loc='upper left')
-        plt.xlabel('Age')
-        plt.ylabel('Incidence (per 100k)')
-        plt.title(f"Cancer Incidence by Age for Birthyear={c.COHORT_YEAR}, Sex={c.COHORT_SEX}, Race={c.COHORT_RACE}, Site={c.CANCER_SITES[0]}")
-        plt.savefig(c.PATHS['plots_calibration'] + f"{c.COHORT_SEX}_{c.COHORT_RACE}_{c.COHORT_YEAR}_{c.CANCER_SITES[0]}.png", bbox_inches='tight')
+        if c.MULTI_COHORT_CALIBRATION:
+            for cohort in tqdm(range(c.FIRST_COHORT, c.LAST_COHORT + 1)):
+                print(f"RUNNING MULTI-COHORT CALIBRATION: FIRST COHORT = {c.FIRST_COHORT}, LAST COHORT = {c.LAST_COHORT}, SEX = {c.COHORT_SEX}, RACE = {c.COHORT_RACE}")
+                print(f"CANCERS = {c.CANCER_SITES}")
+                # Initialize cohort-specific parameters
+                ac_cdf, min_age, max_age, CANCER_PDF, cancer_surv_arr, CANCER_INC = c.select_cohort(cohort, c.CANCER_INC, c.MORT, c.SURV, c.sojourn)
+                model = DiscreteEventSimulation(ac_cdf, cancer_surv_arr)
+                # Run calibration for simplest verion of the model
+                best = simulated_annealing(model, CANCER_PDF, CANCER_INC, min_age, max_age)
+                # Save as numpy file, time_stamped
+                if c.SAVE_RESULTS:
+                    np.save(c.PATHS['calibration'] + f"{c.COHORT_SEX}_{c.COHORT_RACE}_{cohort}_{c.CANCER_SITES[0]}_{datetime.now():%Y-%m-%d_%H-%M-%S}.npy", best)
+                plt.plot(np.arange(c.START_AGE, c.END_AGE), model.run(best).cancerIncArr[:-1], label='Model', color='blue')
+                plt.plot(np.arange(min_age, max_age+1), CANCER_INC, label='SEER', color='darkred', alpha=0.5)
+                plt.legend(loc='upper left')
+                plt.xlabel('Age')
+                plt.ylabel('Incidence (per 100k)')
+                plt.title(f"Cancer Incidence by Age for Birthyear={cohort}, Sex={c.COHORT_SEX}, Race={c.COHORT_RACE}, Site={c.CANCER_SITES[0]}")
+                plt.savefig(c.PATHS['plots_calibration'] + f"{c.COHORT_SEX}_{c.COHORT_RACE}_{cohort}_{c.CANCER_SITES[0]}.png", bbox_inches='tight')
+
+        else:
+            print(f"RUNNING CALIBRATION: COHORT = {c.COHORT_YEAR}, SEX = {c.COHORT_SEX}, RACE = {c.COHORT_RACE}")
+            print(f"CANCERS = {c.CANCER_SITES}")
+            # Initialize cohort-specific parameters
+            ac_cdf, min_age, max_age, CANCER_PDF, cancer_surv_arr, CANCER_INC = c.select_cohort(c.COHORT_YEAR, c.CANCER_INC, c.MORT, c.SURV, c.sojourn)
+            model = DiscreteEventSimulation(ac_cdf, cancer_surv_arr)
+            # Run calibration for simplest verion of the model
+            best = simulated_annealing(model, CANCER_PDF, CANCER_INC, min_age, max_age)
+            # Save as numpy file, time_stamped
+            if c.SAVE_RESULTS:
+                np.save(c.PATHS['calibration'] + f"{c.COHORT_SEX}_{c.COHORT_RACE}_{c.COHORT_YEAR}_{c.CANCER_SITES[0]}_{datetime.now():%Y-%m-%d_%H-%M-%S}.npy", best)
+            plt.plot(np.arange(c.START_AGE, c.END_AGE), model.run(best).cancerIncArr[:-1], label='Model', color='blue')
+            plt.plot(np.arange(min_age, max_age+1), CANCER_INC, label='SEER', color='darkred', alpha=0.5)
+            plt.legend(loc='upper left')
+            plt.xlabel('Age')
+            plt.ylabel('Incidence (per 100k)')
+            plt.title(f"Cancer Incidence by Age for Birthyear={c.COHORT_YEAR}, Sex={c.COHORT_SEX}, Race={c.COHORT_RACE}, Site={c.CANCER_SITES[0]}")
+            plt.savefig(c.PATHS['plots_calibration'] + f"{c.COHORT_SEX}_{c.COHORT_RACE}_{c.COHORT_YEAR}_{c.CANCER_SITES[0]}.png", bbox_inches='tight')
+
 
     end = timer()
     print(f'total time: {timedelta(seconds=end-start)}')

--- a/src/main.py
+++ b/src/main.py
@@ -21,9 +21,9 @@ if __name__ == '__main__':
         plt.show()
     elif c.MODE == 'calibrate':
         if c.MULTI_COHORT_CALIBRATION:
+            print(f"RUNNING MULTI-COHORT CALIBRATION: FIRST COHORT = {c.FIRST_COHORT}, LAST COHORT = {c.LAST_COHORT}, SEX = {c.COHORT_SEX}, RACE = {c.COHORT_RACE}")
+            print(f"CANCERS = {c.CANCER_SITES}")
             for cohort in tqdm(range(c.FIRST_COHORT, c.LAST_COHORT + 1)):
-                print(f"RUNNING MULTI-COHORT CALIBRATION: FIRST COHORT = {c.FIRST_COHORT}, LAST COHORT = {c.LAST_COHORT}, SEX = {c.COHORT_SEX}, RACE = {c.COHORT_RACE}")
-                print(f"CANCERS = {c.CANCER_SITES}")
                 # Initialize cohort-specific parameters
                 ac_cdf, min_age, max_age, CANCER_PDF, cancer_surv_arr, CANCER_INC = c.select_cohort(cohort, c.CANCER_INC, c.MORT, c.SURV, c.sojourn)
                 model = DiscreteEventSimulation(ac_cdf, cancer_surv_arr)
@@ -58,7 +58,7 @@ if __name__ == '__main__':
             plt.ylabel('Incidence (per 100k)')
             plt.title(f"Cancer Incidence by Age for Birthyear={c.COHORT_YEAR}, Sex={c.COHORT_SEX}, Race={c.COHORT_RACE}, Site={c.CANCER_SITES[0]}")
             plt.savefig(c.PATHS['plots_calibration'] + f"{c.COHORT_SEX}_{c.COHORT_RACE}_{c.COHORT_YEAR}_{c.CANCER_SITES[0]}.png", bbox_inches='tight')
-
+            plt.clf()
 
     end = timer()
     print(f'total time: {timedelta(seconds=end-start)}')

--- a/src/main.py
+++ b/src/main.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
                 plt.ylabel('Incidence (per 100k)')
                 plt.title(f"Cancer Incidence by Age for Birthyear={cohort}, Sex={c.COHORT_SEX}, Race={c.COHORT_RACE}, Site={c.CANCER_SITES[0]}")
                 plt.savefig(c.PATHS['plots_calibration'] + f"{c.COHORT_SEX}_{c.COHORT_RACE}_{cohort}_{c.CANCER_SITES[0]}.png", bbox_inches='tight')
-
+                plt.clf()
         else:
             print(f"RUNNING CALIBRATION: COHORT = {c.COHORT_YEAR}, SEX = {c.COHORT_SEX}, RACE = {c.COHORT_RACE}")
             print(f"CANCERS = {c.CANCER_SITES}")

--- a/src/main.py
+++ b/src/main.py
@@ -11,6 +11,9 @@ if __name__ == '__main__':
     start = timer()
     if c.MODE == 'visualize':
         # Run simplest verion of the model
+        # Initialize cohort-specific parameters
+        ac_cdf, min_age, max_age, CANCER_PDF, cancer_surv_arr, CANCER_INC = c.select_cohort(cohort, c.COHORT_SEX, c.COHORT_RACE)
+        model = DiscreteEventSimulation(ac_cdf, cancer_surv_arr)
         print(objective(model.run(c.CANCER_PDF).cancerIncArr, c.CANCER_INC))
         plt.plot(np.arange(c.START_AGE, c.END_AGE), model.run(c.CANCER_PDF).cancerIncArr[:-1], label='Model', color='blue')
         plt.plot(np.arange(c.min_age, c.max_age+1), c.CANCER_INC, label='SEER', color='darkred', alpha=0.5)

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
             print(f"CANCERS = {c.CANCER_SITES}")
             for cohort in tqdm(range(c.FIRST_COHORT, c.LAST_COHORT + 1)):
                 # Initialize cohort-specific parameters
-                ac_cdf, min_age, max_age, CANCER_PDF, cancer_surv_arr, CANCER_INC = c.select_cohort(cohort, c.COHORT_SEX, c.COHORT_RACE, c.CANCER_INC, c.MORT, c.SURV, c.sojourn)
+                ac_cdf, min_age, max_age, CANCER_PDF, cancer_surv_arr, CANCER_INC = c.select_cohort(cohort, c.COHORT_SEX, c.COHORT_RACE)
                 model = DiscreteEventSimulation(ac_cdf, cancer_surv_arr)
                 # Run calibration for simplest verion of the model
                 best = simulated_annealing(model, CANCER_PDF, CANCER_INC, min_age, max_age)
@@ -44,7 +44,7 @@ if __name__ == '__main__':
             print(f"RUNNING CALIBRATION: COHORT = {c.COHORT_YEAR}, SEX = {c.COHORT_SEX}, RACE = {c.COHORT_RACE}")
             print(f"CANCERS = {c.CANCER_SITES}")
             # Initialize cohort-specific parameters
-            ac_cdf, min_age, max_age, CANCER_PDF, cancer_surv_arr, CANCER_INC = c.select_cohort(c.COHORT_YEAR, c.COHORT_SEX, c.COHORT_RACE, c.CANCER_INC, c.MORT, c.SURV, c.sojourn)
+            ac_cdf, min_age, max_age, CANCER_PDF, cancer_surv_arr, CANCER_INC = c.select_cohort(c.COHORT_YEAR, c.COHORT_SEX, c.COHORT_RACE)
             model = DiscreteEventSimulation(ac_cdf, cancer_surv_arr)
             # Run calibration for simplest verion of the model
             best = simulated_annealing(model, CANCER_PDF, CANCER_INC, min_age, max_age)

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,7 @@ if __name__ == '__main__':
             print(f"CANCERS = {c.CANCER_SITES}")
             for cohort in tqdm(range(c.FIRST_COHORT, c.LAST_COHORT + 1)):
                 # Initialize cohort-specific parameters
-                ac_cdf, min_age, max_age, CANCER_PDF, cancer_surv_arr, CANCER_INC = c.select_cohort(cohort, c.CANCER_INC, c.MORT, c.SURV, c.sojourn)
+                ac_cdf, min_age, max_age, CANCER_PDF, cancer_surv_arr, CANCER_INC = c.select_cohort(cohort, c.COHORT_SEX, c.COHORT_RACE, c.CANCER_INC, c.MORT, c.SURV, c.sojourn)
                 model = DiscreteEventSimulation(ac_cdf, cancer_surv_arr)
                 # Run calibration for simplest verion of the model
                 best = simulated_annealing(model, CANCER_PDF, CANCER_INC, min_age, max_age)
@@ -44,7 +44,7 @@ if __name__ == '__main__':
             print(f"RUNNING CALIBRATION: COHORT = {c.COHORT_YEAR}, SEX = {c.COHORT_SEX}, RACE = {c.COHORT_RACE}")
             print(f"CANCERS = {c.CANCER_SITES}")
             # Initialize cohort-specific parameters
-            ac_cdf, min_age, max_age, CANCER_PDF, cancer_surv_arr, CANCER_INC = c.select_cohort(c.COHORT_YEAR, c.CANCER_INC, c.MORT, c.SURV, c.sojourn)
+            ac_cdf, min_age, max_age, CANCER_PDF, cancer_surv_arr, CANCER_INC = c.select_cohort(c.COHORT_YEAR, c.COHORT_SEX, c.COHORT_RACE, c.CANCER_INC, c.MORT, c.SURV, c.sojourn)
             model = DiscreteEventSimulation(ac_cdf, cancer_surv_arr)
             # Run calibration for simplest verion of the model
             best = simulated_annealing(model, CANCER_PDF, CANCER_INC, min_age, max_age)


### PR DESCRIPTION
Created a MUTLI_COHORT_CALIBRATION parameter in configs. When set to True, can specify the full range of cohorts you want to calibrate. Can be used with LOAD_LATEST. Designed so that you calibrate the 1st cohort on its own and once you're satisfied with the fit, then you do the multi cohort calibration starting the next year until the last cohort.